### PR TITLE
Modify install for mac os 10.13.3

### DIFF
--- a/install
+++ b/install
@@ -1,16 +1,26 @@
 #!/bin/bash
 
 INSTALL_DIR=${1:-$(pwd)}
+OPSYS=${2:-"linux"}
 
 echo "Installing into $INSTALL_DIR"
+echo "Assuming operating system $OPSYS"
+
+# check for operating system
+if [[ "$OPSYS" == "linux" ]]; then
+  MEM=$(cat /proc/meminfo | grep MemTotal | sed s/^MemTotal:\\\s*\\\|\\\s\\+[^\\\s]*$//g)
+  MEM=$(($MEM/2/1024/1024))
+elif [[ "$OPSYS" == "osx" ]]; then
+  # sysctl returns total hardware memory size in bytes
+  MEM=$(sysctl hw.memsize | grep hw.memsize | sed s/hw.memsize://g)
+  MEM=$(($MEM/2/1024/1024/1024))
+else
+  echo "ERROR - Operating system (arg2) must be either linux or osx - EXITING"
+  exit
+fi
 
 mvn clean install
 mvn -Dmdep.outputFile=cp.txt -Dmdep.includeScope=runtime dependency:build-classpath
-
-#MEM=$(cat /proc/meminfo | grep MemTotal | sed s/^MemTotal:\\\s*\\\|\\\s\\+[^\\\s]*$//g)
-# sysctl returns total hardware memory size in bytes
-MEM=$(sysctl hw.memsize | grep hw.memsize | sed s/hw.memsize://g)
-MEM=$(($MEM/2/1024/1024/1024))
 
 echo '#!/bin/bash' > n5-view
 echo '' >> n5-view

--- a/install
+++ b/install
@@ -7,8 +7,10 @@ echo "Installing into $INSTALL_DIR"
 mvn clean install
 mvn -Dmdep.outputFile=cp.txt -Dmdep.includeScope=runtime dependency:build-classpath
 
-MEM=$(cat /proc/meminfo | grep MemTotal | sed s/^MemTotal:\\\s*\\\|\\\s\\+[^\\\s]*$//g)
-MEM=$(($MEM/2/1024/1024))
+#MEM=$(cat /proc/meminfo | grep MemTotal | sed s/^MemTotal:\\\s*\\\|\\\s\\+[^\\\s]*$//g)
+# sysctl returns total hardware memory size in bytes
+MEM=$(sysctl hw.memsize | grep hw.memsize | sed s/hw.memsize://g)
+MEM=$(($MEM/2/1024/1024/1024))
 
 echo '#!/bin/bash' > n5-view
 echo '' >> n5-view


### PR DESCRIPTION
I made a small modification to the install script that enabled installation on MacOS 10.13.3. /proc/meminfo doesn't exist in MacOS, so I grabbed system memory size from a system command (sysctl). I added a command line option to specify linux vs. osx to select the appropriate memory size getter; the default is linux. Maven, Oracle JDK1.8, and lib-HDF5 were previously installed. These small changes were enough for install to work. I tested n5-copy (converted .h5 file to .n5 directory) and n5-view (opened .n5 directory) and they both worked. I did not test n5-copy-cremi.

May help others installing on OSX:
OS version: MacOS 10.13.3

Maven version:
Apache Maven 3.5.3 (3383c37e1f9e9b3bc3df5050c29c8aff9f295297; 2018-02-24T14:49:05-05:00)

Java version:
Java version: 1.8.0_161, vendor: Oracle Corporation

HDF5 version:
HDF5 Version: 1.10.1