### PR TITLE
Test for $OSTYPE automatically in install

### DIFF
--- a/install
+++ b/install
@@ -2,16 +2,16 @@
 
 VERSION="0.0.3-SNAPSHOT"
 INSTALL_DIR=${1:-$(pwd)}
-OPSYS=${2:-"linux"}
 
 echo "Installing into $INSTALL_DIR"
-echo "Assuming operating system $OPSYS"
 
 # check for operating system
-if [[ "$OPSYS" == "linux" ]]; then
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  echo "Assuming on Linux operating system"
   MEM=$(cat /proc/meminfo | grep MemTotal | sed s/^MemTotal:\\\s*\\\|\\\s\\+[^\\\s]*$//g)
   MEM=$(($MEM/2/1024/1024))
-elif [[ "$OPSYS" == "osx" ]]; then
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  echo "Assuming on MacOS X operating system"
   # sysctl returns total hardware memory size in bytes
   MEM=$(sysctl hw.memsize | grep hw.memsize | sed s/hw.memsize://g)
   MEM=$(($MEM/2/1024/1024/1024))


### PR DESCRIPTION
* see https://stackoverflow.com/questions/394230/how-to-detect-the-os-from-a-bash-script
* Fixes https://github.com/saalfeldlab/n5-utils/issues/3