### PR TITLE
fix version number in install script

### DIFF
--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.0.5-SNAPSHOT"
+VERSION="0.0.6-SNAPSHOT"
 INSTALL_DIR=${1:-$(pwd)}
 
 echo "Installing into $INSTALL_DIR"


### PR DESCRIPTION
Hi Stefan,

I just tried to install the n5-utils on a fresh system and noticed that the install script still uses the old version number and therefore references the non-existent jar files. Fix attached.

Cheers,
Steffen
