### PR TITLE
Change deprecated bdv.util.volatiles.SharedQueue to bdv.cache.SharedQueue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.1.0</version>
+		<version>33.2.0</version>
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>
@@ -114,15 +114,7 @@
 		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
 		<jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
 
-		<cisd.jhdf5.version>19.04.0</cisd.jhdf5.version>
-		<n5.version>2.4.0</n5.version>
-		<n5-imglib2.version>3.5.1</n5-imglib2.version>
-		<n5-hdf5.version>1.4.2-SNAPSHOT</n5-hdf5.version>
-		<n5-aws-s3.version>3.2.0</n5-aws-s3.version>
-		<n5-blosc.version>1.1.0</n5-blosc.version>
-		<n5-zarr.version>0.0.6</n5-zarr.version>
 		<n5-jpeg.version>0.0.1-beta1</n5-jpeg.version>
-		<n5-google-cloud>3.3.1</n5-google-cloud>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/janelia/saalfeldlab/View.java
+++ b/src/main/java/org/janelia/saalfeldlab/View.java
@@ -144,7 +144,7 @@ import bdv.util.BdvFunctions;
 import bdv.util.BdvOptions;
 import bdv.util.BdvStackSource;
 import bdv.util.RandomAccessibleIntervalMipmapSource;
-import bdv.util.volatiles.SharedQueue;
+import bdv.cache.SharedQueue;
 import bdv.util.volatiles.VolatileViews;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;
 import net.imglib2.RandomAccessible;

--- a/src/main/java/org/janelia/saalfeldlab/cosem/ViewCosem.java
+++ b/src/main/java/org/janelia/saalfeldlab/cosem/ViewCosem.java
@@ -151,7 +151,7 @@ import bdv.util.BdvHandle;
 import bdv.util.BdvOptions;
 import bdv.util.BdvStackSource;
 import bdv.util.RandomAccessibleIntervalMipmapSource;
-import bdv.util.volatiles.SharedQueue;
+import bdv.cache.SharedQueue;
 import bdv.util.volatiles.VolatileViews;
 import bdv.viewer.Source;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;


### PR DESCRIPTION
* Use pom-scijava 33.2.0 for n5 ecosystem versions except for jpeg.
* Change deprecated bdv.util.volatiles.SharedQueue to bdv.cache.SharedQueue