### PR TITLE
update pom-scijava to 37.0.0 to support N5 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>33.2.0</version>
+		<version>37.0.0</version>
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>

--- a/src/main/java/org/janelia/saalfeldlab/Copy.java
+++ b/src/main/java/org/janelia/saalfeldlab/Copy.java
@@ -135,6 +135,7 @@ import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.GzipCompression;
 import org.janelia.saalfeldlab.n5.Lz4Compression;
+import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.RawCompression;
@@ -291,7 +292,7 @@ public class Copy implements Callable<Void> {
 
 				try {
 					n5Writer.setAttribute(groupName, key, n5Reader.getAttribute(groupName, key, clazz));
-				} catch (final IOException e) {
+				} catch (final N5Exception e) {
 					e.printStackTrace(System.err);
 				}
 			}

--- a/src/main/java/org/janelia/saalfeldlab/Equals.java
+++ b/src/main/java/org/janelia/saalfeldlab/Equals.java
@@ -126,6 +126,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.janelia.saalfeldlab.N5Factory.N5Options;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 
@@ -179,7 +180,7 @@ public class Equals implements Callable<Boolean> {
 
 			return equals;
 		}
-		catch (final IOException e) {
+		catch (final N5Exception e) {
 
 			return false;
 		}

--- a/src/main/java/org/janelia/saalfeldlab/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/N5Factory.java
@@ -131,6 +131,7 @@ import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5KeyValueReader;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.googlecloud.N5GoogleCloudStorageReader;
@@ -141,6 +142,7 @@ import org.janelia.saalfeldlab.n5.s3.N5AmazonS3Reader;
 import org.janelia.saalfeldlab.n5.s3.N5AmazonS3Writer;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrWriter;
+import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
@@ -252,7 +254,7 @@ public class N5Factory {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <N5 extends N5FSReader> N5 createN5FS(final String containerPath, final N5AccessType accessType) throws IOException {
+	private static <N5 extends N5KeyValueReader> N5 createN5FS(final String containerPath, final N5AccessType accessType) throws IOException {
 
 		switch (accessType) {
 		case Reader:
@@ -277,7 +279,7 @@ public class N5Factory {
 		}
 	}
 
-	private static <N5 extends N5ZarrReader> N5 createN5Zarr(final String containerPath, final N5AccessType accessType) throws IOException {
+	private static <N5 extends ZarrKeyValueReader> N5 createN5Zarr(final String containerPath, final N5AccessType accessType) throws IOException {
 
 		switch (accessType) {
 		case Reader:
@@ -310,7 +312,7 @@ public class N5Factory {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <N5 extends N5AmazonS3Reader> N5 createN5S3(final String containerPath, final N5AccessType accessType) throws IOException {
+	private static <N5 extends N5KeyValueReader> N5 createN5S3(final String containerPath, final N5AccessType accessType) throws IOException {
 
 		AmazonS3 s3;
 		try {
@@ -329,16 +331,16 @@ public class N5Factory {
 
 		switch (accessType) {
 		case Reader:
-			return (N5) new N5AmazonS3Reader(s3, s3Uri);
+			return (N5) new N5AmazonS3Reader(s3, s3Uri.getBucket());
 		case Writer:
-			return (N5) new N5AmazonS3Writer(s3, s3Uri);
+			return (N5) new N5AmazonS3Writer(s3, s3Uri.getBucket());
 		default:
 			return null;
 		}
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <N5 extends N5GoogleCloudStorageReader> N5 createN5GoogleCloud(final String containerPath, final N5AccessType accessType) throws IOException {
+	private static <N5 extends N5KeyValueReader> N5 createN5GoogleCloud(final String containerPath, final N5AccessType accessType) throws IOException {
 
 		final ResourceManager resourceManager = new GoogleCloudResourceManagerClient().create();
 

--- a/src/main/java/org/janelia/saalfeldlab/View.java
+++ b/src/main/java/org/janelia/saalfeldlab/View.java
@@ -133,6 +133,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 import org.janelia.saalfeldlab.N5Factory.N5Options;
+import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Reader.Version;
@@ -630,7 +631,7 @@ public class View implements Callable<Void> {
 						Version version;
 						try {
 							version = n5.getVersion();
-						} catch (final IOException f) {
+						} catch (final N5Exception f) {
 							f.printStackTrace(System.err);
 							continue;
 						}

--- a/src/main/java/org/janelia/saalfeldlab/cosem/ViewCosem.java
+++ b/src/main/java/org/janelia/saalfeldlab/cosem/ViewCosem.java
@@ -135,6 +135,7 @@ import javax.swing.WindowConstants;
 
 import org.janelia.saalfeldlab.N5Factory;
 import org.janelia.saalfeldlab.N5Factory.N5Options;
+import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Reader.Version;
@@ -479,7 +480,7 @@ public class ViewCosem<T extends NativeType<T> & NumericType<T>>  implements Cal
                     Version version;
                     try {
                         version = n5.getVersion();
-                    } catch (final IOException f) {
+                    } catch (final N5Exception f) {
                         f.printStackTrace(System.err);
                         continue;
                     }


### PR DESCRIPTION
Updated n5-utils to 37.0.0. -- please double check the changes in N5AmazonS3Reader - I added .getBucket() as it seems to be the right thing, but not 100% sure.

Right now n5-utils cannot display N5 3.0.0 anymore ... so this is important I guess.